### PR TITLE
Use COSE Signed Merkle Tree Proofs as a basis for receipts (#22)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
 LIBDIR := lib
+
+# FIXME: workaround for old xml2rfc server no longer working 
+XML_RESOURCE_ORG_PREFIX := https://bib.ietf.org/public/rfc
+
 include $(LIBDIR)/main.mk
 
 $(LIBDIR)/main.mk:

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -578,13 +578,12 @@ We also introduce the following requirements for the COSE signature of the Merkl
 - The SCITT version header MUST be included and its value match the `version` field of the Receipt stucture.
 - The DID of issuer header (like in Signed Claims) MUST be included and its value match the `ts_identifier` field of the Receipt structure.
 - TS MAY include the Registration policy info header to indicate to verifiers what policies have been applied at the registration of this claim.
-- Since {{-COMETRE}} uses optional headers, the `crit` header (id: 2) MUST be included and all SCITT-specific headers (version, issuer DID and Registration Policy) MUST be marked critical.
+- Since {{-COMETRE}} uses optional headers, the `crit` header (id: 2) MUST be included and all SCITT-specific headers (version, DID of TS and Registration Policy) MUST be marked critical.
 
 The following registration policies are built-in and MAY be used by verifiers to help decide the trustworthiness of the Transparent Statement:
 
 - Registration time: the timestamp at which the TS has added this Signed Claim to its Registry
-- DID Manifest: the manifest that was retured by resolving the DID of the issuer at registration, according to the TS.
-- Sequence number: the sequence number of this statement with relation to other statements with the same issuer and feed. There is no guarantee that all Signed Statements are registered with contiguous sequence numbers; only that it is monotonic and follows the issuer sequence numbers.
+- [TODO]: Discuss and add additional policies
 
 ~~~ cddl
 Receipt = [
@@ -595,24 +594,22 @@ Receipt = [
 
 ; Additional protected headers in the COSE signed_tree_root of the SignedMerkleTreeProof
 Protected_Header = {
-  390 => int               ; SCITT Receipt Version
-  391 => tstr              ; DID of Issuer (required)
-  ? 393 => RegistrationInfo  ; Registration policy information (optional)
+  390 => int                 ; SCITT Receipt Version
+  394 => tstr                ; DID of Transparency Service (required)
+  ? 395 => RegistrationInfo  ; Registration policy information (optional)
 
   ; Other COSE Signed Merkle Tree headers
   ; (e.g. tree algorithm, tree size)
 
-  ; Optional standard COSE headers
+  ; Additional standard COSE headers
   2 => [+ label]            ; Critical headers
-  ? 4 => bstr                ; Key ID (optional)
-  ? 33 => COSE_X509	         ; X.509 chain (optional)
+  ? 4 => bstr               ; Key ID (optional)
+  ? 33 => COSE_X509	    ; X.509 chain (optional)
 }
 
 ; Details of the registration policies applied by the TS
 RegistrationInfo = {
   ? "registration_time": uint .within (~time),
-  ? "did_manifest": bstr,
-  ? "sequence_no": uint,
   * tstr => any
 }
 ~~~

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -693,7 +693,7 @@ Conversely, the service MAY re-issue Receipts for the Registry content, for inst
 ## Validation of Transparent Statements
 
 This section provides additional implementation considerations.
-The high-level validation algorithm is described in {{validation}}; the Registry-specific details of checking Receipts are covered in {{-COSEMTP}}.
+The high-level validation algorithm is described in {{validation}}; the Registry-specific details of checking Receipts are covered in {{-COMTRE}}.
 
 Before checking a Transparent Statement, the Verifier must be configured with one or more identities of trusted Transparency Services.
 If more than one service is configured, the Verifier MUST return which service the Transparent Statement is registered on.

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -604,8 +604,8 @@ Protected_Header = {
 
   ; Optional standard COSE headers
   2 => [+ label]            ; Critical headers
-  4 => bstr                ; Key ID (optional)
-  33 => COSE_X509	         ; X.509 chain (optional)
+  ? 4 => bstr                ; Key ID (optional)
+  ? 33 => COSE_X509	         ; X.509 chain (optional)
 }
 
 ; Details of the registration policies applied by the TS

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -603,7 +603,7 @@ Protected_Header = {
   ; (e.g. tree algorithm, tree size)
 
   ; Optional standard COSE headers
-  2 => [+label]            ; Critical headers
+  2 => [+ label]            ; Critical headers
   4 => bstr                ; Key ID (optional)
   33 => COSE_X509	         ; X.509 chain (optional)
 }

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -238,7 +238,7 @@ and on prior Signed Statements already added to a Registry.
 Registry:
 
 : the verifiable append-only data structure that stores Signed Statements in a Transparency Service often referred to by the synonym log or ledger.
-Since COSE Signed Merkle Tree Proofs ({{-COSEMTP}}) support multiple Merkle Tree algorithms, SCITT supports different Transparency Service implementations of the Registry, such as historical Merkle Trees or sparse Merkle Trees.
+Since COSE Signed Merkle Tree Proofs ({{-COMETRE}}) support multiple Merkle Tree algorithms, SCITT supports different Transparency Service implementations of the Registry, such as historical Merkle Trees or sparse Merkle Trees.
 
 Signed Statement:
 

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -595,7 +595,7 @@ Receipt = [
 
 ; Additional protected headers in the COSE signed_tree_root of the SignedMerkleTreeProof
 Protected_Header = {
-  390 => int               ; SCITT Version
+  390 => int               ; SCITT Receipt Version
   391 => tstr              ; DID of Issuer (required)
   393 => RegistrationInfo  ; Registration policy information (optional)
 

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -223,7 +223,7 @@ An Issuer may be the owner or author of software Artifacts, or an independent th
 
 Receipt:
 
-: a Receipt is a cryptographic proof that a Signed Statement is recorded in the Registry. Receipts are based on COSE Signed Merkle Tree Proofs {{-COSEMTP}}; they consist of a Registry-specific inclusion proof, a signature by the Transparency Service of the state of the Registry, and additional metadata (contained in the signature's protected headers) to assist in auditing.
+: a Receipt is a cryptographic proof that a Signed Statement is recorded in the Registry. Receipts are based on COSE Signed Merkle Tree Proofs {{-COMETRE}}; they consist of a Registry-specific inclusion proof, a signature by the Transparency Service of the state of the Registry, and additional metadata (contained in the signature's protected headers) to assist in auditing.
 
 Registration:
 

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -75,7 +75,7 @@ normative:
     target: https://w3c-ccg.github.io/did-method-web/
     title: did:web Decentralized Identifiers Method Spec
 informative:
-  I-D.draft-steele-cose-merkle-tree-proofs: COSEMTP
+  I-D.draft-steele-cose-merkle-tree-proofs: COMETRE
   PBFT: DOI.10.1145/571637.571640
   MERKLE: DOI.10.1007/3-540-48184-2_32
   RFC9334: rats-arch

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -597,7 +597,7 @@ Receipt = [
 Protected_Header = {
   390 => int               ; SCITT Receipt Version
   391 => tstr              ; DID of Issuer (required)
-  393 => RegistrationInfo  ; Registration policy information (optional)
+  ? 393 => RegistrationInfo  ; Registration policy information (optional)
 
   ; Other COSE Signed Merkle Tree headers
   ; (e.g. tree algorithm, tree size)

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -568,7 +568,7 @@ Unprotected_Header = {
 
 ## Receipts
 
-Receipts are based on COSE Signed Merke Tree Proofs ({{-COSEMTP}}) with an additional wrapper structure that adds the following information:
+Receipts are based on COSE Signed Merkle Tree Proofs ({{-COMETRE}}) with an additional wrapper structure that adds the following information:
 
 - version: Receipt version number; this should be set to `0` for implementation of this document. We envision that future version of SCITT may add support for more complex receipts; for instance, registrations on multiple TS, receipts for dependency graphs and endorsements of Signed Claims, etc.
 - ts_identifier: The DID of the Transparency Service that issued the claim. Verifiers MAY use this DID as a key discovery mechanism to verify the COSE Merkle Root signature; in this case the verification is the same as for Signed Claims and the signer should include the Key ID header. Verifiers MUST support the `did:web` method, all other methods are optional.

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -693,7 +693,7 @@ Conversely, the service MAY re-issue Receipts for the Registry content, for inst
 ## Validation of Transparent Statements
 
 This section provides additional implementation considerations.
-The high-level validation algorithm is described in {{validation}}; the Registry-specific details of checking Receipts are covered in {{-COMTRE}}.
+The high-level validation algorithm is described in {{validation}}; the Registry-specific details of checking Receipts are covered in {{-COMETRE}}.
 
 Before checking a Transparent Statement, the Verifier must be configured with one or more identities of trusted Transparency Services.
 If more than one service is configured, the Verifier MUST return which service the Transparent Statement is registered on.

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -578,7 +578,7 @@ We also introduce the following requirements for the COSE signature of the Merkl
 - The SCITT version header MUST be included and its value match the `version` field of the Receipt stucture.
 - The DID of issuer header (like in Signed Claims) MUST be included and its value match the `ts_identifier` field of the Receipt structure.
 - TS MAY include the Registration policy info header to indicate to verifiers what policies have been applied at the registration of this claim.
-- Since {{-COSEMTP}} uses optional headers, the `crit` header (id: 2) MUST be included and all SCITT-specific headers (version, issuer DID and Registration Policy) MUST be marked critical.
+- Since {{-COMETRE}} uses optional headers, the `crit` header (id: 2) MUST be included and all SCITT-specific headers (version, issuer DID and Registration Policy) MUST be marked critical.
 
 The following registration policies are built-in and MAY be used by verifiers to help decide the trustworthiness of the Transparent Statement:
 

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -341,7 +341,7 @@ Auditor       -->     / Collect Receipts /      /   Replay Log    /
 The SCITT architecture consists of a very loose federation of Transparency Services, and a set of common formats and protocols for issuing, registering and auditing Transparent Statements.
 
 In order to accommodate as many Transparency Service implementations as possible, this document only specifies the format of Signed Statements (which must be used by all Issuers) and a very thin wrapper format for Receipts, which specifies the Transparency Service identity and the agility parameters for the Merkle Tree Proof.
-Most of the details of the Receipt's contents are specified in the COSE Signed Merkle Tree Proof document {{-COSEMTP}}.
+Most of the details of the Receipt's contents are specified in the COSE Signed Merkle Tree Proof document {{-COMETRE}}.
 
 In this section, a high level the three main roles and associated processes in SCITT: Issuers and the Signed Statement issuance process, transparency Registry and the Transparent Statement Registration process, as well as  Verifiers and the Receipt validation process.
 


### PR DESCRIPTION
As proposed in at the WG meeting in Tokyo, we would like to move receipts as a generic primitive in COSE. (see issue #22)

This PR removes all explicit references to the SCITT receipt ID and instead defines Receipts based on [Orie's COSE Signer Merkle Tree Proof ID](https://ietf-scitt.github.io/draft-steele-cose-merkle-tree-proofs/letmaik/remove-non-rfc-tree-algs/draft-steele-cose-merkle-tree-proofs.html#name-signed-merkle-tree-proof).

Note that I also incorporated 2 proposed changes to make SCITT statement and receipt signature more symmetrical:
- Receipts now include the DID of the transparency service. This can be optionally used to discover the receipt signing key. This change was originally proposed at the IETF WG meeting in London. It simplifies statement authorization, as verifiers can only trust the stable DID of the TS instead of worry about keys or certificate that may be rotated
- Transparency services can now indicate the registration policies that were actually applied. This is very helpful for verifier, for instance to check the freshness of claims. This was proposed in Tokyo