### PR TITLE
Use CWT Claims in Headers

### DIFF
--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -688,7 +688,6 @@ Protected_Header = {
   4 => bstr              ; Key ID
   13 => CWT_Claims       ; CBOR Web Token Registered Claims
   ; TBD, Labels are temporary
-  391 => tstr            ; DID of Issuer // redundant
   392 => tstr            ; Feed // redundant
   393 => Reg_Info        ; Registration Policy info
 }

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -688,7 +688,6 @@ Protected_Header = {
   4 => bstr              ; Key ID
   13 => CWT_Claims       ; CBOR Web Token Registered Claims
   ; TBD, Labels are temporary
-  392 => tstr            ; Feed // redundant
   393 => Reg_Info        ; Registration Policy info
 }
 

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -670,7 +670,7 @@ COSE_Sign1 = [
 <!-- https://www.iana.org/assignments/cwt/cwt.xhtml -->
 CWT_Claims = {
   1 => tstr; iss, the issuer that is making statements
-  2 -> tstr; sub, the subject about which the statements are made, throughout this spec, this is also called feed.
+  2 => tstr; sub, the subject about which the statements are made, throughout this spec, this is also called feed.
   * tstr => any
 }
 

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -666,6 +666,13 @@ COSE_Sign1 = [
   payload : bstr,
   signature : bstr
 ]
+<!-- https://datatracker.ietf.org/doc/draft-ietf-cose-cwt-claims-in-headers/ -->
+<!-- https://www.iana.org/assignments/cwt/cwt.xhtml -->
+CWT_Claims = {
+  1 => tstr; iss, the issuer that is making statements
+  2 -> tstr; sub, the subject about which the statements are made, throughout this spec, this is also called feed.
+  * tstr => any
+}
 
 Reg_Info = {
   ? "register_by": uint .within (~time),
@@ -679,9 +686,10 @@ Protected_Header = {
   1 => int               ; algorithm identifier
   3 => tstr              ; payload type
   4 => bstr              ; Key ID
+  13 => CWT_Claims       ; CBOR Web Token Registered Claims
   ; TBD, Labels are temporary
-  391 => tstr            ; DID of Issuer
-  392 => tstr            ; Feed
+  391 => tstr            ; DID of Issuer // redundant
+  392 => tstr            ; Feed // redundant
   393 => Reg_Info        ; Registration Policy info
 }
 


### PR DESCRIPTION
This PR shows that feed is redundant to CWT Claims in headers.
If this approach gains consensus we won't need to register special tags in the protected header, and can instead use the RFC that allows this to happen.

For context, see this discussion from the list:

https://mailarchive.ietf.org/arch/msg/cose/KNRge3vxXF3A2LY24DNo6ZQxrNc/