### PR TITLE
Update RKVST branding to DataTrails

### DIFF
--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -47,8 +47,8 @@ author:
   country: UK
 - ins: S. Lasker
   name: Steve Lasker
-  org: RKVST
-  email: steve.lasker@rkvst.com
+  org: DataTrails
+  email: steve.lasker@datatrails.ai
   city: Seattle
   country: United States
 


### PR DESCRIPTION
RKVST has re-branded to DataTrails. Update to reflect my new email and company branding. 