### PR TITLE
Link to default HTML format for RFC9393 reference

### DIFF
--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -75,7 +75,7 @@ normative:
   IANA.params:
   IANA.cose:
   COSWID:
-    target: https://www.rfc-editor.org/rfc/rfc9393.pdf
+    target: https://www.rfc-editor.org/rfc/rfc9393
     title:  COSWID Specification
   CWT_CLAIM_COSE:
     target: https://datatracker.ietf.org/doc/draft-ietf-cose-cwt-claims-in-headers/


### PR DESCRIPTION
A minor nit, but in the current version of the draft only RFC 9393 (COSWID) links to its PDF form, not the default HTML form. It is minor, but hopefully more (eventual) consistency is a good thing.