### PR TITLE
Remove Reg_Info

### DIFF
--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -808,7 +808,7 @@ The following requirements for the COSE signature of the Merkle Root are added:
 
 - The SCITT version header MUST be included and its value match the `version` field of the Receipt structure
 - The DID of Issuer header (in Signed Statements) MUST be included and its value match the `ts_identifier` field of the Receipt structure
-- Transparency Service MUST include the Registration policy info header to indicate to Verifiers what policies have been applied at the registration of this Statement
+- Transparency Service MUST include additional claims in the protected header of Receipts to indicate the policies evaluated during the registration of a Statement
 - Since {{-COMETRE}} uses optional headers, the `crit` header (id: 2) MUST be included and all SCITT-specific headers (version, DID of Transparency Service and Registration Policy) MUST be marked critical
 
 The Transparency Service may include the registration time to help Verifiers decide about the trustworthiness of the Transparent Statement.

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -787,7 +787,7 @@ CWT_Claims = {
 Protected_Header = {
   1   => int             ; algorithm identifier,
   4   => bstr            ; Key ID,
-  13  => CWT_Claims      ; CBOR Web Token Claims,
+  15  => CWT_Claims      ; CBOR Web Token Claims,
   3   => tstr            ; payload type
 }
 

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -864,11 +864,6 @@ Editor's Note: The WG is discussing if existing CWT claims might better support 
 ~~~ cddl
 label = int / tstr
 value = any
-; Additional protected headers
-; in the COSE signed_tree_root of the SignedMerkleTreeProof
-Protected_Header = {
-  390 => int         ; SCITT Receipt Version
-  394 => tstr        ; DID of Transparency Service (required)
 
 Receipt_Unprotected_Header = {
   &(scitt-inclusion-proof: 396) => bstr .cbor inclusion-proof

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -421,7 +421,7 @@ CWT_Claims = {
 Protected_Header = {
   1   => int             ; algorithm identifier,
   4   => bstr            ; Key ID (kid),
-  13  => CWT_Claims      ; CBOR Web Token Claims,
+  15  => CWT_Claims      ; CBOR Web Token Claims,
   3   => tstr            ; payload type
 }
 ~~~

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -781,7 +781,7 @@ Signed Statements may be registered by a different party than their Issuer.
 1. **Signature verification:** The Transparency Service MUST verify the signature of the Signed Statement, as described in {{RFC9360}}, using the signature algorithm and verification key of the Issuer.
 1. **Signed Statement validation:** The Transparency Service MUST check that the Signed Statement includes the required protected headers listed above.
 The Transparency Service MAY verify the Statement payload format, content and other optional properties.
-1. **Apply Registration Policy:** For named policies, the Transparency Service MUST check the attributes required by the policy are present in the protected headers.
+1. **Apply Registration Policy:** The Transparency Service MUST check the attributes required by a policy are present in the protected headers.
   Custom Signed Statements are evaluated given the current Transparency Service state and the entire Envelope, and may use information contained in the attributes of named policies.
 1. **Register the Signed Statement** to the append-only log
 1. **Return the Transparent Statement**, which includes the Receipt

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -573,7 +573,7 @@ Issuers MAY use different signing keys (identified by `kid` in the resolved key 
 ### Registration Policy Metadata
 
 SCITT payloads are opaque to Transparency Services.
-For interoperability, Registration Policy decisions should be based on interpretation of the mandatory metadata in the non-opaque Envelope of a Signed Statement.
+For interoperability, Registration Policy decisions should be based on interpretation of the mandatory metadata in the protected header of a Signed Statement.
 
 Each implementation of a Transparency Service MAY support additional metadata, specific to its implementation through additional ["Reserved for Private Use"](https://www.iana.org/assignments/cwt/cwt.xhtml#claims-registry) keys within the `CWT_Claims` header.
 

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -861,6 +861,9 @@ The registration time is defined as the timestamp at which the Transparency Serv
 
 Editor's Note: The WG is discussing if existing CWT claims might better support these design principles.
 
+~~~ cddl
+label = int / tstr
+value = any
 ; Additional protected headers
 ; in the COSE signed_tree_root of the SignedMerkleTreeProof
 Protected_Header = {


### PR DESCRIPTION
Based on discussions at IETF and subsequent editors meetings, this proposal removes `reg_info` as not required by all Transparency Service implementations. 
Transparency Services MAY implement optional information using `CWT_Claims` and the ["private use" implementation keys](https://www.iana.org/assignments/cwt/cwt.xhtml#claims-registry) available

Fixes #19, #103, #127