### PR TITLE
Add package.json with aasvg

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "aasvg": "0.3"
+  }
+}


### PR DESCRIPTION
As suggested in https://github.com/martinthomson/i-d-template/issues/385#issuecomment-1564100412, there should be a `package.json`. Then running `make` will automatically install aasvg (assuming that npm is installed, which I am documenting in https://github.com/martinthomson/i-d-template/pull/419).

Without this (and without aasvg installed otherwise), running `make` will throw an error:

```
/usr/lib/ruby/3.1.0/open3.rb:222:in `spawn': No such file or directory - aasvg (Errno::ENOENT)
        from /usr/lib/ruby/3.1.0/open3.rb:222:in `popen_run'
        from /usr/lib/ruby/3.1.0/open3.rb:103:in `popen3'
        from /usr/lib/ruby/3.1.0/open3.rb:290:in `capture3'
        from /draft-ietf-scitt-architecture/lib/.gems/ruby/3.1.0/gems/kramdown-rfc2629-1.7.4/lib/kramdown-rfc2629.rb:557:in `svg_tool_process'
        from /draft-ietf-scitt-architecture/lib/.gems/ruby/3.1.0/gems/kramdown-rfc2629-1.7.4/lib/kramdown-rfc2629.rb:506:in `call'
[...]
```