### PR TITLE
Improve introduction

### DIFF
--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -136,63 +136,47 @@ Within the SCITT Architecture, a producer is known as an Issuer, and a consumer 
 
 # Introduction
 
-This document describes a scalable and flexible, decentralized architecture to enhance auditability and accountability across various existing and emerging supply chains.
-It achieves this goal by enforcing the following complementary security guarantees:
+This document describes the scalable, flexible, and decentralized SCITT architecture.
+Its goal is to enhance auditability and accountability across supply chains.
 
-1. Statements made by Issuers about supply chain Artifacts must be identifiable, authentic, and non-repudiable
-1. Such Statements must be registered on a secure Append-only Log, enabling provenance and history to be independently and consistently audited
-1. Issuers can efficiently prove to any other party the Registration of their Signed Statements; verifying this proof ensures that the Issuer is consistent and non-equivocal when producing Signed Statements
+In supply chains, there are producers and consumers of items.
+Consumers may like to have information about the items that they consume, such as an item's provenance.
+SCITT provides a way for consumers to obtain this information in a way that is "transparent", that is, producers cannot lie about the information without it being detected.
+SCITT achieves this by having producers (also called Issuers) publish information in a Transparency Service, where consumers (also called Verifiers) can check the information.
+
+SCITT consists of the following roles: Issuers, Transparency Services, Verifiers, and Auditors.
+The process works as follows:
+
+1. Issuers make Statements about Artifacts they release, for example: "Issuer name", "Artifact type", "Artifact version".
+1. Issuers sign the Statements, producing Signed Statements.
+1. Issuers submit the Signed Statements to Transparency Services.
+1. Transparency Services take the submitted Signed Statements and insert them into an Append-only Log, producing Transparent Statements.
+They may add their own metadata such as: "Transparency Service name", "Artifact registration time", "registration policy used".
+This process can be thought of as Transparency Services counter-signing Issuers' Signed Statements.
+Transparency Services have a Registration Policy controlling what can be submitted.
+They may also have an authorization policy controlling who can access their service.
+1. Verifiers consume the Transparent Statements, verifying them in order to be convinced of the Statement about the Artifact.
+1. Auditors verify the correctness and consistency of the Transparent Statements.
+
+An entity can take on multiple roles, for example, an entity can act both as an Issuer and as a Verifier.
+An Issuer can make multiple Statements about the same Artifact.
+Multiple Issuers can issue Statements about the same Artifact.
+
+SCITT provides the following security guarantees:
+
+1. Statements made by Issuers about supply chain Artifacts are identifiable, authentic, and non-repudiable.
+1. Statement provenance and history can be independently and consistently audited.
+1. Issuers can efficiently prove that their Statement is logged by a Transparency Service.
 
 The first guarantee is achieved by requiring Issuers to sign their Statements and associated metadata using a distributed public key infrastructure.
-The second guarantee is achieved by storing the Signed Statement on an immutable, Append-only Log.
-The next guarantee is achieved by implementing the Append-only Log using a verifiable data structure (such as a Merkle Tree {{MERKLE}}).
-Lastly, the Transparency Service verifies the identity of the Issuer, and conformance to a Registration Policy associated with the instance of the Transparency Service.
-As the Issuer of the Signed Statement and conformance to the Registration Policy are confirmed, an endorsement is made as the Signed Statement is added to the Append-only Log.
+The second guarantee is achieved by storing the Signed Statement on an Append-only Log.
+The third guarantee is achieved by implementing the Append-only Log using a verifiable data structure (such as a Merkle Tree {{MERKLE}}).
 
-The guarantees and techniques used in this document generalize those of Certificate Transparency {{-CT}}, which can be re-interpreted as an instance of this architecture for the supply chain of X.509 certificates.
-However, the range of use cases and applications in this document is broader, which requires more flexibility in how each Transparency Service is implemented and operates.
-
-Each service MAY enforce its own Registration Policies for authorizing entities to register their Signed Statements to the Append-only Log.
-Some Transparency Services may also enforce authorization policies limiting who can write, read and audit the Append-only Log.
-It is critical to provide interoperability for all Transparency Services instances as the composition of supply chain entities is ever-changing.
-It is implausible to expect all participants to choose a single vendor or Append-only Log.
-
-A Transparency Service provides visibility into Signed Statements associated with various supply chains and their sub-systems.
-The Signed Statements (and inner payload) make claims about the Artifacts produced by a supply chain.
-A Transparency Service endorses specific and well-defined metadata about Artifacts which are captured in the envelope of the Statements.
-Some metadata is selected (and signed) by the Issuer ("who issued the Statement", "what type of Artifact is described", "what is the Artifact's version").
-Whereas additional metadata is selected (and countersigned) by the Transparency Services ("when was the Signed Statement about an Artifact registered in the Transparency Service", "which registration policy was used").
-Evaluating and Registering a Signed Statement, adding it to the Append-only Log, and producing a Transparent Statement is considered a form of counter-signed notarization.
-
-A Statements payload content is always opaque and MAY be encrypted when submitted to the Transparency Services.
-However the header metadata MUST be transparent in order to warrant trust for later processing.
-
-Transparent Statements provide a common basis for holding Issuers accountable for the Statement payload about Artifacts they release.
-Multiple Issuers may Register additional Signed Statements about the same Artifact, but they cannot delete or alter Signed Statements previously added to the Append-only Log.
-The ability for the original Issuer to make additional Statements about an Artifact provides for updated information to be shared, such as new positive or negative validations of quality.
-The ability of other Issuers to make Statements about an Artifact, produced from another Issuer, provides for third party validations.
-A Transparency Service may restrict access to Signed Statements through access control or Registration policies.
-However, third parties (such as Auditors) would be granted access as needed to attest to the validity of the Artifact, Subject or the entirety of the Transparency Service.
-Independent third parties may also make Statements about an Artifact, published on other Transparency Services.
-
-Trust in the Transparency Service itself is supported both by protecting their implementation (using replication, trusted hardware, and remote attestation of a system's operational state) and by enabling independent audits of the correctness and consistency of its Append-only Log, thereby holding the organization that operates it accountable.
-Unlike CT, where independent Auditors are responsible for enforcing the consistency of multiple independent instances of the same global Transparency Service, each Transparency Service is required to guarantee the consistency of its own Append-only Log (through the use of a consensus algorithm between replicas of the Transparency Service), but assume no consistency between different Transparency Services.
-
-Breadth of verifier access is critical.
-As a result, the Transparency Service specified in this architecture caters to two types of audiences:
-
-1. **Issuers**: organizations, stakeholders, and users involved in creating or attesting to supply chain artifacts, releasing authentic Statements to a definable set of peers
-1. **Verifiers**: organizations, stakeholders, consumers, and users involved in validating supply chain artifacts, but can only do so if the Statements are known to be authentic.
-Verifiers MAY be Issuers, providing additional Signed Statements, attesting to conformance of various compliance requirements.
-
-The Issuer of a Signed Statement must be authenticated and authorized according to the Registration Policy of the Transparency Service.
-Analogously, Transparent Statement Verifiers rely on verifiable trustworthiness assertions associated with Transparent Statements and their processing provenance in a believable manner.
-If trust can be put into the operations that record Signed Statements in a secure, Append-only Log via online operations, the same trust can be put into the resulting Transparent Statement, issued by the Transparency Services and that can be validated in offline operations.
-
-The Transparency Services specified in this architecture are language independent and can be implemented alongside or within existing services.
-
-The interoperability guaranteed by the Transparency Services is enabled via core components (architectural constituents).
-Many of the data elements processed by the core components are based on the CBOR Signing and Encryption (COSE) standard specified in {{-COSE}}, which is used to produce Signed Statements about Artifacts and to build and maintain an Append-only Log for corresponding Signed Statements.
+SCITT is a generalisation of Certificate Transparency {{-CT}}, which can be interpreted as a transparency architecture for the supply chain of X.509 certificates.
+CAs (Issuers) sign X.509 TBSCertificates (Artifacts) to produce X.509 certificates (Signed Statements).
+CAs then submit the certificates to one or more CT logs (Transparency Services).
+The CT logs produce Signed Certificate Timestamps (Transparent Statements).
+The SCTs are checked by browsers (Verifiers), and the Append-only Log can be checked by Auditors.
 
 ## Requirements Notation
 

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -130,8 +130,6 @@ This document defines a generic, interoperable and scalable architecture to enab
 It provides flexibility, enabling interoperability across different implementations of Transparency Services with various auditing and compliance requirements.
 Issuers can register their Signed Statements on any Transparency Service, with the guarantee that all Consumers will be able to verify them.
 
-Within the SCITT Architecture, a producer is known as an Issuer, and a consumer is known as a Verifier.
-
 --- middle
 
 # Introduction
@@ -139,44 +137,17 @@ Within the SCITT Architecture, a producer is known as an Issuer, and a consumer 
 This document describes the scalable, flexible, and decentralized SCITT architecture.
 Its goal is to enhance auditability and accountability across supply chains.
 
-In supply chains, there are producers and consumers of items.
-Consumers may like to have information about the items that they consume, such as an item's provenance.
-SCITT provides a way for consumers to obtain this information in a way that is "transparent", that is, producers cannot lie about the information without it being detected.
-SCITT achieves this by having producers (also called Issuers) publish information in a Transparency Service, where consumers (also called Verifiers) can check the information.
+In supply chains, items travel down the chain until they are eventually consumed by someone.
+Consumers like to have information about the items that they consume.
+There are many parties who publish information about an item:
+For example, the original manufacturer may provide information about the state of the item when it left the factory.
+The shipping company may add information about the transport environment of the item.
+Compliance auditors may provide information about their compliance assessment of the item.
+Security companies may publish vulnerability information about an item.
+Consumers may even publish the fact that they consume an item.
 
-SCITT consists of the following roles: Issuers, Transparency Services, Verifiers, and Auditors.
-The process works as follows:
-
-1. Issuers make Statements about Artifacts they release, for example: "Issuer name", "Artifact type", "Artifact version".
-1. Issuers sign the Statements, producing Signed Statements.
-1. Issuers submit the Signed Statements to Transparency Services.
-1. Transparency Services take the submitted Signed Statements and insert them into an Append-only Log, producing Transparent Statements.
-They may add their own metadata such as: "Transparency Service name", "Artifact registration time", "registration policy used".
-This process can be thought of as Transparency Services counter-signing Issuers' Signed Statements.
-Transparency Services have a Registration Policy controlling what can be submitted.
-They may also have an authorization policy controlling who can access their service.
-1. Verifiers consume the Transparent Statements, verifying them in order to be convinced of the Statement about the Artifact.
-1. Auditors verify the correctness and consistency of the Transparent Statements.
-
-An entity can take on multiple roles, for example, an entity can act both as an Issuer and as a Verifier.
-An Issuer can make multiple Statements about the same Artifact.
-Multiple Issuers can issue Statements about the same Artifact.
-
-SCITT provides the following security guarantees:
-
-1. Statements made by Issuers about supply chain Artifacts are identifiable, authentic, and non-repudiable.
-1. Statement provenance and history can be independently and consistently audited.
-1. Issuers can efficiently prove that their Statement is logged by a Transparency Service.
-
-The first guarantee is achieved by requiring Issuers to sign their Statements and associated metadata using a distributed public key infrastructure.
-The second guarantee is achieved by storing the Signed Statement on an Append-only Log.
-The third guarantee is achieved by implementing the Append-only Log using a verifiable data structure (such as a Merkle Tree {{MERKLE}}).
-
-SCITT is a generalisation of Certificate Transparency {{-CT}}, which can be interpreted as a transparency architecture for the supply chain of X.509 certificates.
-CAs (Issuers) sign X.509 TBSCertificates (Artifacts) to produce X.509 certificates (Signed Statements).
-CAs then submit the certificates to one or more CT logs (Transparency Services).
-The CT logs produce Signed Certificate Timestamps (Transparent Statements).
-The SCTs are checked by browsers (Verifiers), and the Append-only Log can be checked by Auditors.
+SCITT provides a way for consumers to obtain this information in a way that is "transparent", that is, parties cannot lie about the information that they publish without it being detected.
+SCITT achieves this by having producers, auditors, etc. (also called Issuers) publish information in a Transparency Service, where consumers (also called Verifiers) can check the information.
 
 ## Requirements Notation
 
@@ -185,6 +156,19 @@ The SCTs are checked by browsers (Verifiers), and the Append-only Log can be che
 # Use Cases
 
 The building blocks defined in SCITT are intended to support applications in any supply chain that produces or relies upon digital artifacts, from the build and supply of software and IoT devices to advanced manufacturing and food supply.
+
+## Relation to Certificate Transparency
+
+SCITT is a generalization of Certificate Transparency {{-CT}}, which can be interpreted as a transparency architecture for the supply chain of X.509 certificates.
+Considering CT in terms of SCITT:
+
+- CAs (Issuers) sign X.509 TBSCertificates (Artifacts) to produce X.509 certificates (Signed Statements)
+- CAs submit the certificates to one or more CT logs (Transparency Services)
+- CT logs produce Signed Certificate Timestamps (Transparent Statements)
+- SCTs are checked by browsers (Verifiers)
+- The Append-only Log can be checked by Auditors
+
+Note that just like CT logs are independent and their contents need not be consistent, Transparency Services are similarly independent of each other.
 
 # Terminology {#terminology}
 
@@ -938,6 +922,18 @@ Issuers MUST ensure that the Statement payloads in their Signed Statements are c
 
 Issuers and Transparency Services MUST carefully protect their private signing keys and avoid these keys being used for any purpose not described in this architecture document.
 In cases where key re-use is unavoidable, keys MUST NOT sign any other message that may be verified as an Envelope as part of a Signed Statement.
+
+## Security Guarantees
+
+SCITT provides the following security guarantees:
+
+1. Statements made by Issuers about supply chain Artifacts are identifiable, authentic, and non-repudiable
+1. Statement provenance and history can be independently and consistently audited
+1. Issuers can efficiently prove that their Statement is logged by a Transparency Service
+
+The first guarantee is achieved by requiring Issuers to sign their Statements and associated metadata using a distributed public key infrastructure.
+The second guarantee is achieved by storing the Signed Statement on an Append-only Log.
+The third guarantee is achieved by implementing the Append-only Log using a verifiable data structure (such as a Merkle Tree {{MERKLE}}).
 
 ## Threat Model
 


### PR DESCRIPTION
The previous introduction was very long, contained too much detail, and did not follow a clear logical structure (i.e. no clear chain-of-thought).

Therefore here is my attempt at improving that:

- start with a high-level scenario to motivate the problem
- then provide a rough sketch of how the protocol works
  -  This may be moved to Section 5 "Architecture Overview"? On the other hand, we do need the terminology to compare SCITT with CT, and the steps are a good way to introduce them concisely.
- then state the security guarantees
- end with comparing SCITT to CT (as per https://mailarchive.ietf.org/arch/msg/scitt/1oW4DRFFb1g230VmZVQVgj_Mdw8/ )
  - Shameless plug: see [my blog](https://thore.io/posts/2023/07/how-certificates-are-born-data-structure-edition/) for an overview of X.509 certs, SCTs, and how they are constructed.

I'm sure my attempt isn't perfect either, but I hope it's an incremental improvement and I welcome feedback :)

Click below to expand the detailed analysis of why I dislike the old introduction:

<details>

A general pattern that I dislike across the introduction (but also in the rest of the document) is a tendancy to write long sentences. Sentences, that when rendered as TXT, are up to seven lines long. I consciously tried to keep it shorter.
Imho technical standards should be short, concise, approachable, and easily skimmable.

Another general pattern I dislike is the use of keywords (MAY, MUST) in the introduction. Imho that's bad practice -- the introduction should provide a rough overview, not specify anything binding.

More specific points (quote from the old text, followed by my comment/assessment, in order of appearance):

> The second guarantee is achieved by storing the Signed Statement on an immutable, Append-only Log.

Either the log is immutable or append-only (i.e., mutable with restrictions). It can't be both. => Remove "immutable".

> Lastly, the Transparency Service verifies the identity of the Issuer, [...] Signed Statement is added to the Append-only Log.

How does this relate to the security guarantees?? I removed this sentence.

> However, the range of use cases and applications in this document is broader, which requires more flexibility in how each Transparency Service is implemented and operates.

Stating the obvious, might as well delete.

> Each service MAY enforce its own Registration Policies for authorizing entities to register their Signed Statements to the Append-only Log.

Why use the BCP 14 keywords in the introduction (here: MAY)? The purpose of an introduction should be to give a high level overview, not to specify something. This MAY-statement would better belong to Section 5.2.2.

Also, is this entire paragraph necessary for an introduction? Eight lines, just to say that Transparency Services can have policies. Imho policies are a detail that doesn't need to be in the introduction.

> It is critical to provide interoperability for all Transparency Services instances as the composition of supply chain entities is ever-changing.

Redundant. The whole points of IETF is to provide interoperability.

> A Statements payload content is always opaque and MAY be encrypted when submitted to the Transparency Services. However the header metadata MUST be transparent in order to warrant trust for later processing.

Again, why use BCP 14 keywords (especially a binding MUST) in the introduction??

Also, this is again too much detail for the introduction.

> However, third parties (such as Auditors) would be granted access as needed to attest to the validity of the Artifact, Subject or the entirety of the Transparency Service.

Stating the obvious. No access, no audit.

> Independent third parties may also make Statements about an Artifact, published on other Transparency Services.

Redundant, repeats what the same paragraph says earlier.

> Breadth of verifier access is critical.

Stating the obvious. If there are no verifiers, we don't need SCITT.

> As a result, the Transparency Service specified in this architecture caters to two types of audiences: [...]

How does this link to the previous sentence??
Why suddenly talk about issuers after starting the paragraph with  "verifier access is critical"?

> The Transparency Services specified in this architecture are language independent and can be implemented alongside or within existing services.

Obvious. Of course it doesn't matter whether I implement it in C, Rust, or Python. This is why we write RFCs, to define standard interfaces.

> The interoperability guaranteed by the Transparency Services is enabled via core components (architectural constituents).

Obvious. Again, IETF is all about interoperability.

> Many of the data elements processed by the core components are based on the CBOR Signing and Encryption (COSE) standard specified in [RFC9052], which is used to produce Signed Statements about Artifacts and to build and maintain a Merkle tree that functions as an Append-only Log for corresponding Signed Statements.

Too much detail for an introduction.

</details>