### PR TITLE
Add more details to Privacy Considerations

### DIFF
--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -930,7 +930,8 @@ Downstream producers benefit from upstream producers providing higher transparen
 
 # Privacy Considerations
 
-Usually Transparency Services are publicly accessible, hence Issuers should treat Signed Statements that they register (rendering them as Transparent Statements) as public.
+Transparency Services are often publicly accessible.
+Issuers should treat Signed Statements (rendering them as Transparent Statements) as publicly accessible.
 In particular, a Signed Statement Envelope and Statement payload should not carry any private information in plaintext.
 
 Transparency Services can have an authorization policy controlling who can access the Append-only Log.

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -933,7 +933,7 @@ Downstream producers benefit from upstream producers providing higher transparen
 Usually Transparency Services are publicly accessible, hence Issuers should treat Signed Statements that they register (rendering them as Transparent Statements) as public.
 In particular, a Signed Statement Envelope and Statement payload should not carry any private information in plaintext.
 
-Transparency Services can have an authorization policy controlling who can access the Log.
+Transparency Services can have an authorization policy controlling who can access the Append-only Log.
 While this can be used to limit who can read the Log, it may also limit the usefulness of the system.
 
 Some jurisdictions have a Right to be Forgotten.

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -939,7 +939,6 @@ While this can be used to limit who can read the Log, it may also limit the usef
 
 Some jurisdictions have a Right to be Forgotten.
 However, once a Signed Statement is inserted into the Append-only Log maintained by a Transparency Service, it cannot be removed from the Log.
-The only way to delete the Signed Statement is to delete the entire Log and start a new one.
 
 # Security Considerations
 

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -930,8 +930,15 @@ Downstream producers benefit from upstream producers providing higher transparen
 
 # Privacy Considerations
 
-Unless advertised by a Transparency Service, every Issuer must treat Signed Statements it registered (rendering them as Transparent Statements) as public.
-In particular, a Signed Statement Envelope and Statement payload MUST NOT carry any private information in plaintext.
+Usually Transparency Services are publicly accessible, hence Issuers should treat Signed Statements that they register (rendering them as Transparent Statements) as public.
+In particular, a Signed Statement Envelope and Statement payload should not carry any private information in plaintext.
+
+Transparency Services can have an authorization policy controlling who can access the Log.
+While this can be used to limit who can read the Log, it may also limit the usefulness of the system.
+
+Some jurisdictions have a Right to be Forgotten.
+However, once a Signed Statement is inserted into the Append-only Log maintained by a Transparency Service, it cannot be removed from the Log.
+The only way to delete the Signed Statement is to delete the entire Log and start a new one.
 
 # Security Considerations
 


### PR DESCRIPTION
This PR elaborates on the privacy analysis a bit.

1. Describe why it is important (because we cannot delete items from the log)
2. Remove the BCP 14 keyword (MUST NOT). 
    - Both the Privacy and Security Considerations sections should have the character of an analysis. They should be recommendations, or highlight gotchas to implementors. Anything binding should be in the main body of the RFC.
    - Yes, this would need to be fixed in the Security Considerations, too.
3. Expand the "Unless advertised by a Transparency Service" phrase into a paragraph about access control. This way it's more actionable. (Why would you advertise it? When would it be okay to advertise?)

