### PR TITLE
Update CODEOWNERS 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-# Automatically generated CODEOWNERS
-# Regenerate with `make update-codeowners`
-draft-ietf-scitt-architecture.md henk.birkholz@sit.fraunhofer.de antdl@microsoft.com fournet@microsoft.com yogesh.deshpande@arm.com
+# Reflecting authors, editors and active contributors
+
+* @henkbirkholz @ad-l @fournet @yogeshbdeshpande @stevelasker @JAG-UK @OR13 @aj-stein-nist


### PR DESCRIPTION
Update CODEOWNERS to reflect the authors, editor, and active contributors for PR reviews