### PR TITLE
Restoring Append-only security requirements

### DIFF
--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -220,7 +220,7 @@ Over time, an Issuer may register new Signed Statements about an Artifact in a T
 Receipt:
 
 : a cryptographic proof that a Signed Statement is included in the Append-only Log.
-Receipts are based on Signed Inclusion Proofs as described in COSE Signed Merkle Tree Proofs {{-COMETRE}};
+Receipts are based on Signed Inclusion Proofs, such as those as described in COSE Signed Merkle Tree Proofs {{-COMETRE}};
 they can be built on different verifiable data structures, not just binary merkle trees.
 A receipt consists of an Transparency Service-specific inclusion proof for the Signed Statement, a signature by the Transparency Service of the state of the Append-only Log after the inclusion, and additional metadata (contained in the signature's protected headers) to assist in auditing.
 

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -222,7 +222,7 @@ Receipt:
 : a cryptographic proof that a Signed Statement is included in the Append-only Log.
 Receipts are based on Signed Inclusion Proofs, such as those as described in COSE Signed Merkle Tree Proofs {{-COMETRE}};
 they can be built on different verifiable data structures, not just binary merkle trees.
-A receipt consists of an Transparency Service-specific inclusion proof for the Signed Statement, a signature by the Transparency Service of the state of the Append-only Log after the inclusion, and additional metadata (contained in the signature's protected headers) to assist in auditing.
+A Receipt consists of an Transparency Service-specific inclusion proof for the Signed Statement, a signature by the Transparency Service of the state of the Append-only Log after the inclusion, and additional metadata (contained in the signature's protected headers) to assist in auditing.
 
 Registration:
 

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -430,7 +430,7 @@ Everyone with access to its content sees the same collection of Signed Statement
 
 Replayability:
 
-: the Append-only Log includes sufficient information to enable everyone with access to its content to check that each included Signed Statement has been correctly registered.
+: the Append-only Log includes sufficient information to enable authorised actors with access to its content to check that each included Signed Statement has been correctly registered.
 
 In addition to Receipts, some verifiable data structures might support additional proof types, such as proofs of consistency, or proofs of non inclusion.
 

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -416,7 +416,7 @@ Transparency Services MUST support at least one of these methods:
 
 ### Append-only Log
 
-The security properties of the Append-only Log are determined by the choice of the verifiable data structure used by the Transparency Service to produce Receipts.
+The security properties of the Append-only Log are determined by the choice of the verifiable data structure used by the Transparency Service to implement the Log.
 This verifiable data structure MUST support the following security requirements:
 
 Append-Only:

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -87,7 +87,6 @@ informative:
   I-D.draft-ietf-cose-merkle-tree-proofs: COMETRE
 
   RFC2397: DataURLs
-  RFC6024:
   RFC8141: URNs
   RFC9162: CT
   RFC9334: rats-arch
@@ -372,8 +371,7 @@ This section describes at a high level, the three main roles and associated proc
 ## Transparency Service
 
 Transparency Services MUST feature an Append-only Log.
-The Append-only Log is a verifiable data structure that accumulates all Signed Statements 
-registered by the Transparency Service and that supports the production of Receipts.
+The Append-only Log is a verifiable data structure that accumulates all Signed Statements registered by the Transparency Service and that supports the production of Receipts.
 
 All Transparency Services MUST expose APIs for the registration of Signed Statements and issuance of Receipts.
 
@@ -391,8 +389,6 @@ Transparency Services MUST maintain Registration Policies which govern whether o
 
 Registration Policies MUST be made transparent and available to all clients of the Transparency Service by registering them as Signed Statements on the Append-only Log.
 
-
-
 This specification leaves implementation, encoding and documentation of Registration Policies to the operator of the Transparency Service.
 
 #### Mandatory Registration Checks
@@ -403,7 +399,6 @@ Transparency Services MUST, at a minimum, perform the following checks before re
 
 The Transparency Service MUST authenticate the Issuer of Signed Statements by validating the COSE signature and checking the identity of the issuer through one of its configured trust anchors, using the `x5t` and `kid` headers in the protected header as hints. For instance, for X.509 signed claims the Transparency Service must validate a complete certificate chain from the certificate identified by `x5t` to one of the trusted root authority certificate of the Transparency Service.
 The public key is used to verify digital signatures, and the associated data is used to constrain the types of information for which the trust anchor is authoritative."
-
 
 Before a Signed Statement is registered, the trust anchor used to verify its Issuer MUST be registered with the Transparency Service.
 
@@ -418,25 +413,25 @@ Transparency Services MUST support at least one of these methods:
 
 ### Append-only Log
 
-The security properties of the Append-only Log are determined by the choice of the verifiable data structure used by the Transparency Service to produce Receipts. 
+The security properties of the Append-only Log are determined by the choice of the verifiable data structure used by the Transparency Service to produce Receipts.
 This verifiable data structure MUST support the following security requirements:
 
-Append-Only: 
+Append-Only:
 
-: once included in the verifiable data structure, a Signed Statement cannot be modified, deleted, or reordered; hence its Receipt provides a universally-verifiable proof of registration. 
+: once included in the verifiable data structure, a Signed Statement cannot be modified, deleted, or reordered; hence its Receipt provides a universally-verifiable proof of registration.
 
-Non-equivocation: 
+Non-equivocation:
 
 : there is no fork in the Append-only Log. Everyone with access to its content sees the same collection of Signed Statements, and can check that it is consistent with any Receipts they have verified.
 
 Replayability:
 
-: the Append-only Log includes sufficient information to enable everyone with access to its content 
-to check that each included Signed Statement has been correctly registered. 
+: the Append-only Log includes sufficient information to enable everyone with access to its content to check that each included Signed Statement has been correctly registered.
 
 In addition to Receipts, some verifiable data structures might support additional proof types, such as proofs of consistency, or proofs of non inclusion.
 
 Specific verifiable data structures, such those describes in {{-CT}} and {{-COMETRE}}, and the review of their security requirements for SCITT are out of scope for this document.
+
 ### Adjacent Services
 
 Transparency Services can be deployed along side other database or object storage technologies.
@@ -1152,3 +1147,4 @@ A Signed Statement (cose-sign1) MUST be produced from the to-be-signed bytes acc
 | COSE Sign 1  |
  '------------'
 ~~~
+

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -222,7 +222,7 @@ Receipt:
 : a cryptographic proof that a Signed Statement is included in the Append-only Log.
 Receipts are based on Signed Inclusion Proofs as described in COSE Signed Merkle Tree Proofs {{-COMETRE}};
 they can be built on different verifiable data structures, not just binary merkle trees.
-A receipts consists of an Transparency Service-specific inclusion proof for the Signed Statement, a signature by the Transparency Service of the state of the Append-only Log after the inclusion, and additional metadata (contained in the signature's protected headers) to assist in auditing.
+A receipt consists of an Transparency Service-specific inclusion proof for the Signed Statement, a signature by the Transparency Service of the state of the Append-only Log after the inclusion, and additional metadata (contained in the signature's protected headers) to assist in auditing.
 
 Registration:
 

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -425,7 +425,8 @@ Append-Only:
 
 Non-equivocation:
 
-: there is no fork in the Append-only Log. Everyone with access to its content sees the same collection of Signed Statements, and can check that it is consistent with any Receipts they have verified.
+: there is no fork in the Append-only Log.
+Everyone with access to its content sees the same collection of Signed Statements and can check that it is consistent with any Receipts they have verified.
 
 Replayability:
 

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -374,7 +374,7 @@ This section describes at a high level, the three main roles and associated proc
 ## Transparency Service
 
 Transparency Services MUST feature an Append-only Log.
-The Append-only Log is a verifiable data structure that accumulates all Signed Statements registered by the Transparency Service and that supports the production of Receipts.
+The Append-only Log is the verifiable data structure that records Signed Statements and supports the production of Receipts.
 
 All Transparency Services MUST expose APIs for the registration of Signed Statements and issuance of Receipts.
 

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -421,7 +421,7 @@ This verifiable data structure MUST support the following security requirements:
 
 Append-Only:
 
-: once included in the verifiable data structure, a Signed Statement cannot be modified, deleted, or reordered; hence its Receipt provides a universally-verifiable proof of registration.
+: once included in the verifiable data structure, a Signed Statement cannot be modified, deleted, or reordered; hence its Receipt provides an offline verifiable proof of registration.
 
 Non-equivocation:
 

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -177,7 +177,7 @@ The terms "header", "payload", and "to-be-signed bytes" are defined in {{RFC9052
 
 Append-only Log (Ledger):
 
-: the verifiable append-only data structure that stores Signed Statements in a Transparency Service, often referred to by the synonym, Ledger.
+: the verifiable append-only data structure that stores Signed Statements in a Transparency Service, often referred to by the synonym Ledger.
 SCITT supports multiple Ledger and Receipt formats to accommodate different Transparency Service implementations, and the proof types associated with different types of Append-only Logs.
 
 Artifact:
@@ -202,7 +202,7 @@ In COSE, an Envelope consists of a protected header (included in the Issuer's si
 
 Equivocation:
 
-: a state where it is possible for a Transparency Service to provide different views of its Append-only log to Verifiers about the same Artifact {{EQUIVOCATION}}.
+: a state where it is possible for a Transparency Service to provide different views of its Append-only Log to Verifiers about the same Artifact {{EQUIVOCATION}}.
 
 Feed:
 
@@ -216,15 +216,15 @@ An Issuer may be the owner or author of Artifacts, or an independent third party
 
 Non-equivocation:
 
-: a state where it is impossible for a Transparency Service to provide different views of its append-only log to Verifiers about the same Artifact.
+: a state where it is impossible for a Transparency Service to provide different views of its Append-only Log to Verifiers about the same Artifact.
 Over time, an Issuer may register new Signed Statements about an Artifact in a Transparency Service with new information. However, the consistency of a collection of Signed Statements about the Artifact can be checked by all Verifiers.
 
 Receipt:
 
-: a Receipt is a cryptographic proof that a Signed Statement is recorded in the Append-only Log.
-Receipts are based on Signed Inclusion Proofs as described in COSE Signed Merkle Tree Proofs {{-COMETRE}}.
-Receipts can be built on different verifiable data structures, not just binary merkle trees.
-Receipts consist of Transparency Service-specific inclusion proofs, a signature by the Transparency Service of the state of the Append-only Log, and additional metadata (contained in the signature's protected headers) to assist in auditing.
+: a cryptographic proof that a Signed Statement is included in the Append-only Log.
+Receipts are based on Signed Inclusion Proofs as described in COSE Signed Merkle Tree Proofs {{-COMETRE}};
+they can be built on different verifiable data structures, not just binary merkle trees.
+A receipts consists of an Transparency Service-specific inclusion proof for the Signed Statement, a signature by the Transparency Service of the state of the Append-only Log after the inclusion, and additional metadata (contained in the signature's protected headers) to assist in auditing.
 
 Registration:
 
@@ -372,7 +372,8 @@ This section describes at a high level, the three main roles and associated proc
 ## Transparency Service
 
 Transparency Services MUST feature an Append-only Log.
-The Append-only Log is the verifiable data structure that registers Signed Statements and supports the production of Receipts.
+The Append-only Log is a verifiable data structure that accumulates all Signed Statements 
+registered by the Transparency Service and that supports the production of Receipts.
 
 All Transparency Services MUST expose APIs for the registration of Signed Statements and issuance of Receipts.
 
@@ -417,12 +418,26 @@ Transparency Services MUST support at least one of these methods:
 
 ### Append-only Log
 
-The security properties of the Append-only Log are determined by the choice of the verifiable data structure used to produce Receipts.
+The security properties of the Append-only Log are determined by the choice of the verifiable data structure used by the Transparency Service to produce Receipts. 
+This verifiable data structure MUST support the following security requirements:
+
+Append-Only: 
+
+: once included in the verifiable data structure, a Signed Statement cannot be modified, deleted, or reordered; hence its Receipt provides a universally-verifiable proof of registration. 
+
+Non-equivocation: 
+
+: there is no fork in the Append-only Log. Everyone with access to its content sees the same collection of Signed Statements, and can check that it is consistent with any Receipts they have verified.
+
+Replayability:
+
+: the Append-only Log includes sufficient information to enable everyone with access to its content 
+to check that each included Signed Statement has been correctly registered. 
 
 In addition to Receipts, some verifiable data structures might support additional proof types, such as proofs of consistency, or proofs of non inclusion.
 
-Specific verifiable data structures, such those describes in {{-CT}} and {{-COMETRE}} are out of scope for this document.
-
+Specific verifiable data structures, such those describes in {{-CT}} and {{-COMETRE}}, and the review of their security requirements for SCITT are out of scope for this document.
+q
 ### Adjacent Services
 
 Transparency Services can be deployed along side other database or object storage technologies.

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -437,7 +437,6 @@ to check that each included Signed Statement has been correctly registered.
 In addition to Receipts, some verifiable data structures might support additional proof types, such as proofs of consistency, or proofs of non inclusion.
 
 Specific verifiable data structures, such those describes in {{-CT}} and {{-COMETRE}}, and the review of their security requirements for SCITT are out of scope for this document.
-q
 ### Adjacent Services
 
 Transparency Services can be deployed along side other database or object storage technologies.

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -222,7 +222,7 @@ Receipt:
 : a cryptographic proof that a Signed Statement is included in the Append-only Log.
 Receipts are based on Signed Inclusion Proofs, such as those as described in COSE Signed Merkle Tree Proofs {{-COMETRE}};
 they can be built on different verifiable data structures, not just binary merkle trees.
-A Receipt consists of an Transparency Service-specific inclusion proof for the Signed Statement, a signature by the Transparency Service of the state of the Append-only Log after the inclusion, and additional metadata (contained in the signature's protected headers) to assist in auditing.
+A Receipt consists of a Transparency Service-specific inclusion proof for the Signed Statement, a signature by the Transparency Service of the state of the Append-only Log after the inclusion, and additional metadata (contained in the signature's protected headers) to assist in auditing.
 
 Registration:
 


### PR DESCRIPTION
See issue  #199 

The requirements in ### Append-only Log are restored (and much simplified) from earlier drafts, notably what used to be in ### Append-only Log Security Requirements.

The other changes are minor changes for uniformity about the Append-only Log. 
 