### PR TITLE
Remove distributed from intro

### DIFF
--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -271,7 +271,7 @@ Transparency Services use `sub` to identify the entity about which they are issu
 Transparency Service:
 
 : an entity that maintains and extends the Append-only Log, and endorses its state.
-A Transparency Service can be a complex distributed system, and SCITT requires the Transparency Service to provide many security guarantees about its Append-only Log.
+A Transparency Service can be a complex system, requiring the Transparency Service to provide many security guarantees about its Append-only Log.
 The identity of a Transparency Service is captured by a public key that must be known by Relying Parties in order to validate Receipts.
 
 Transparent Statement:


### PR DESCRIPTION
Addressing feedback to the SCITT alias
> 1)	The introduction discusses distributed, but there is no real discussion of how or what that means and it leads readers to set an expectation that is incorrect.  This word should be deleted.