### PR TITLE
Update Transparent Statement to Signed Statement. 

### DIFF
--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -446,7 +446,6 @@ Specific verifiable data structures, such those describes in {{-CT}} and {{-COME
 
 Transparency Services can be deployed along side other database or object storage technologies.
 For example, a Transparency Service that is supporting a software package management system, might be referenced from the APIs exposed for package management.
-Each version of the package would represent an artifact, by which Signed Statements are registered, including provenance of the package, known vulnerabilities or newer version information.
 Providing an ability to request a fresh receipt for a given software package, or to request a list of Signed Statements associated with the software package.
 
 ## Signed Statements

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -410,7 +410,7 @@ The Transparency Service MUST apply the Registration Policy that was most recent
 
 The operator of a Transparency Service MAY update the Registration Policy or the trust anchors of a Transparency Service at any time.
 
-Transparency Services MUST ensure that for any Signed Statement they register, enough information is made available to Auditors (either in the Append-only Log and retrievable through audit APIs, or included in the Receipt) to authenticate and retrieve the Transparent Statements describing the registration policy and trust anchors that apply to this registration.
+Transparency Services MUST ensure that for any Signed Statement they register, enough information is made available to Auditors (either in the Append-only Log and retrievable through audit APIs, or included in the Receipt) to authenticate and retrieve the Signed Statements describing the registration policy and trust anchors that apply to this registration.
 
 ### Initialization and bootstrapping {#ts-initialization}
 
@@ -446,7 +446,8 @@ Specific verifiable data structures, such those describes in {{-CT}} and {{-COME
 
 Transparency Services can be deployed along side other database or object storage technologies.
 For example, a Transparency Service that is supporting a software package management system, might be referenced from the APIs exposed for package management.
-Providing an ability to request a fresh receipt for a given software package, or to request a list of Signed Statements and Artifacts associated with a software package.
+Each version of the package would represent an artifact, by which Signed Statements are registered, including provenance of the package, known vulnerabilities or newer version information.
+Providing an ability to request a fresh receipt for a given software package, or to request a list of Signed Statements associated with the software package.
 
 ## Signed Statements
 


### PR DESCRIPTION
from [scitt alias feedback](https://mailarchive.ietf.org/arch/msg/scitt/O3nkTYsEqYzA-DF1wVW-Q7cpJn4/):
> In section 4.1.1.2 it alludes that an auditor can mine the log to authenticate and retrieve the transparent statement.  Based on the last statement this has two problems.  The first it assumes that the signed statement is kept and that it can generate a new receipt (see 3) and produce a transparent statement.  If it could this would be equivalent to the original in intent but not binary equal.   The original receipt (or last created receipt from a refresh) is not required (or intended) to be kept in the ledger.  Generically then this is impossible and may be where we would leverage consistency proofs in a later version.



