### PR TITLE
Allow protected x5chain

### DIFF
--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -419,8 +419,9 @@ During Registration, a Transparency Service MUST, at a minimum, syntactically ch
 The Issuer identity MUST be bound to the Signed Statement by including an identifier in the protected header.
 If the protected header includes multiple identifiers, all those that are registered by the Transparency Service MUST be checked.
 
-In essence, when using X.509 Signed Statements, the Transparency Service MUST build and validate a complete certificate chain from the Issuer's certificate identified by `x5t` located in the protected header of the COSE_Sign1 Envelope, to one of the root certificates most recently registered as a trust anchor of the Transparency Service.
-An `x5chain` with a leaf certificate that corresponds to the `x5t` value MAY be included in the unprotected header.
+In essence, when using X.509 Signed Statements, the Transparency Service MUST build and validate a complete certificate chain from the Issuer's certificate, to one of the root certificates most recently registered as a trust anchor of the Transparency Service.
+
+The protected header of the COSE_Sign1 Envelope MUST include one of: the Issuer's certificate as `x5t`, or the chain including the Issuer's certificate as `x5chain`. If `x5t` is included in the protected header, an `x5chain` with a leaf certificate that corresponds to the `x5t` value MAY be included in the unprotected header.
 
 The Transparency Service MUST apply the Registration Policy that was most recently added to the Append-only Log at the time of Registration.
 
@@ -502,16 +503,16 @@ Relying Parties can choose which Issuers they trust.
 
 Multiple Issuers can make the same Statement about a single Artifact, affirming multiple Issuers agree.
 
-At least one identifier representing one credential MUST be included in the protected header of the COSE Envelope, as one of `x5t` or `kid`.
+At least one identifier representing one credential MUST be included in the protected header of the COSE Envelope, as one of `x5t`, `x5chain` or `kid`.
 Additionally, `x5chain` that corresponds to either `x5t` or `kid` identifying the leaf certificate in the included certification path MAY be included in the unprotected header of the COSE Envelope.
 
-- When using x.509 certificates, support for `x5t` is REQUIRED to implement.
+- When using x.509 certificates, support for either `x5t` or `x5chain` in the protected header is REQUIRED to implement.
 - Support for `kid` in the protected header and `x5chain` in the unprotected header is OPTIONAL to implement.
 
-When `x5t` is present, `iss` MUST be a string that meets URI requirements defined in {{RFC8392}}.
+When `x5t` or `x5chain` is present in the protected header, `iss` MUST be a string that meets URI requirements defined in {{RFC8392}}.
 The `iss` value's length MUST be between 1 and 8192 characters in length.
 
-The `kid` header parameter MUST be present when `x5t` is not present.
+The `kid` header parameter MUST be present when neither `x5t` nor `x5chain` is present in the protected header.
 Key discovery protocols are out-of-scope of this document.
 
 The protected header of a Signed Statement and a Receipt MUST include the `CWT Claims` header parameter as specified in {{Section 2 of CWT_CLAIMS_COSE}}.

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -421,7 +421,8 @@ If the protected header includes multiple identifiers, all those that are regist
 
 In essence, when using X.509 Signed Statements, the Transparency Service MUST build and validate a complete certificate chain from the Issuer's certificate, to one of the root certificates most recently registered as a trust anchor of the Transparency Service.
 
-The protected header of the COSE_Sign1 Envelope MUST include one of: the Issuer's certificate as `x5t`, or the chain including the Issuer's certificate as `x5chain`. If `x5t` is included in the protected header, an `x5chain` with a leaf certificate that corresponds to the `x5t` value MAY be included in the unprotected header.
+The protected header of the COSE_Sign1 Envelope MUST include either the Issuer's certificate as `x5t` or the chain including the Issuer's certificate as `x5chain`.
+If `x5t` is included in the protected header, an `x5chain` with a leaf certificate corresponding to the `x5t` value MAY be included in the unprotected header.
 
 The Transparency Service MUST apply the Registration Policy that was most recently added to the Append-only Log at the time of Registration.
 

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -419,7 +419,7 @@ During Registration, a Transparency Service MUST, at a minimum, syntactically ch
 The Issuer identity MUST be bound to the Signed Statement by including an identifier in the protected header.
 If the protected header includes multiple identifiers, all those that are registered by the Transparency Service MUST be checked.
 
-In essence, when using X.509 Signed Statements, the Transparency Service MUST build and validate a complete certificate chain from the Issuer's certificate, to one of the root certificates most recently registered as a trust anchor of the Transparency Service.
+In essence, when using X.509 Signed Statements, the Transparency Service MUST build and validate a complete certification path from an Issuer's certificate to one of the root certificates most recently registered as a trust anchor by the Transparency Service.
 
 The protected header of the COSE_Sign1 Envelope MUST include either the Issuer's certificate as `x5t` or the chain including the Issuer's certificate as `x5chain`.
 If `x5t` is included in the protected header, an `x5chain` with a leaf certificate corresponding to the `x5t` value MAY be included in the unprotected header.


### PR DESCRIPTION
Resolves #307, by allowing the use of a single, protected `x5chain` header parameter instead of a protected `x5t` and unprotected `x5chain` pair, for reasons described in the issue.

This allows implementations to avoid the risk highlighted at the end of [Security Considerations](https://github.com/ietf-wg-scitt/draft-ietf-scitt-architecture/blob/main/draft-ietf-scitt-architecture.md#security-considerations), at the expense of a slightly larger protected header.

This is not a purely theoretical concern, the most widely used signing service inside Microsoft has implemented this choice, and the separate [Open Source signing tool](https://github.com/microsoft/CoseSignTool) from Microsoft has too.