### PR TITLE
Separate roles from actions

### DIFF
--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -344,52 +344,52 @@ Each Transparency Service produces a Receipt, which may be aggregated in a singl
 The arrows indicate the flow of information.
 
 ~~~aasvg
- .----------.
-|  Artifact  |
- '-----+----'
-       v             +--------------------+
-  .----+----.        | Issuer Credentials |
- | Statement |       +--------+--+--------+
-  '----+----'       cose sign |  | cose verify
-       |    .----------------'|  |
-       |   |                  |  |
-       v   v                  |  |'----------.
-  .----+---+---.              |  |            |
- |    Signed    |             |  |            |
- |   Statement  |             |  |            |
- | (COSE_Sign1) |             |  |            |
-  '------+-----'              v  v            |
-         |                +---+--+--------+   |
-     .--' '-------------->+ Transparency  |   |
-    |   .--------.        |               |   |
-    |  | Receipt  +<------+   Service     +-+ |
-    |  |          +.      +--+------------+ | |
-    |   '-+------'  |        | Transparency | |
-    |     | Receipt +<-------+              | |
-    |      '------+'         |   Service    | |
-     '-------. .-'           +------------+-+ |
-              |                           |   |
-              v                           |   |
-        .-----+-----.                     |   |
-       | Transparent |                    |   |
-       |  Statement  |                    |   |
-        '-----+-----'                     |   |
-              |                           |   |
-              |'-----------.   .----------)--'
-              |             | |           |
-              |             v v           |
-              |    .--------+-+---------. |
-              |   / Verify Transparent /  |
-              |  /      Statement     /   |
-              | '----+-----+---------+    |
-              |      | Relying Party |    |
-              |      +---------------+    |
-              v                           v
-  .-----------+----------.    .-----------+------.
- /  Collecting Receipt  /    /    Replay Log    /
-'------+---------------+    '--+---------------+
-       | Relying Party |       | Relying Party |
-       +---------------+       +---------------+
+                        +------------+
+ .----------.           |   Issuer   |
+|  Artifact  |          +-+--------+-+
+ '----+-----'             v        v
+      v          .--------+-.    .-+--------.
+ .----+----.    /   sign   /    /  verify  /
+| Statement |  '-----+----+    '------+---+
+ '----+----'         |                |
+      |    .--------' '--.            |
+      |   |               |           |
+      v   v               |        .-' '-.
+ .----+---+---.           |       |       |
+|    Signed    |          |       |       |
+|   Statement  |          |       |       |
+ '------+-----'           v       v       |
+        |             +---+-------+---+   |
+    .--' '----------->+ Transparency  |   |
+   |   .--------.     |               |   |
+   |  | Receipt  +<---+   Service     +-+ |
+   |  |          +.   +--+------------+ | |
+   |   '-+------'  |     | Transparency | |
+   |     | Receipt +<----+              | |
+   |      '------+'      |   Service    | |
+    '-------. .-'        +------------+-+ |
+             |                        |   |
+             v                        |   |
+       .-----+-----.                  |   |
+      | Transparent |                 |   |
+      |  Statement  |                 |   |
+       '--+--------'                  |   |
+          |                           |   |
+          |'-----------.   .----------)--'
+          |             | |           |
+          |             v v           |
+          |    .--------+-+---------. |
+          |   / Verify Transparent /  |
+          |  /      Statement     /   |
+          | '----+---------------+    |
+          |      | Relying Party |    |
+          |      +---------------+    |
+          v                           v
+  .-------+-------------.  .----------+------.
+ / Collecting Receipts /  /   Replay Log    /
+'-----+---------------+  '-+---------------+
+      | Relying Party |    | Relying Party |
+      +---------------+    +---------------+
 ~~~
 {: #fig-concept-relationship title="Relationship of Concepts in SCITT"}
 


### PR DESCRIPTION
From the editors call on 11/12/24
- With the addition of the relying party roles, make the top consistent
- Change the hanging text for sign/verify to actions
- Move Issuer as the entity that performs the actions
- Cleanup overly detailed row for COSE_SIGN1
- Narrow the diagram to avoid make warnings

![image](https://github.com/user-attachments/assets/32dcc791-3e42-40bb-bf8f-429e77d5372c)
