### PR TITLE
Clarify trust anchor wording

### DIFF
--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -578,7 +578,7 @@ Multi-tenant support can be enabled through the use of identifiers in the `iss` 
 Registration Policies refer to additional checks over and above the Mandatory Registration Checks that are performed before a Signed Statement is accepted to be registered to the Append-only Log.
 
 Transparency Services MUST maintain Registration Policies.
-Transparency Services MUST maintain a list of trust anchors (see definition of trust anchor in {{-Glossary}}) to verify Issuers of Signed Statements, either separately, or inside Registration Policies.
+Transparency Services MUST maintain a list of trust anchors (see definition of trust anchor in {{-Glossary}}) in order to check the signatures of Signed Statements, either separately, or inside Registration Policies.
 Transparency Services MUST authenticate Signed Statements as part of a Registration Policy.
 For instance, a trust anchor could be an X.509 root certificate (directly or its thumbprint), a pointer to an OpenID Connect identity provider, or any other COSE-compatible trust anchor.
 

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -578,9 +578,9 @@ Multi-tenant support can be enabled through the use of identifiers in the `iss` 
 Registration Policies refer to additional checks over and above the Mandatory Registration Checks that are performed before a Signed Statement is accepted to be registered to the Append-only Log.
 
 Transparency Services MUST maintain Registration Policies.
-Transparency Services MUST maintain a list of trust anchors (see definition of trust anchor in {{-Glossary}}) to verify Issuers of Signed Statements.
+Transparency Services MUST maintain a list of trust anchors (see definition of trust anchor in {{-Glossary}}) to verify Issuers of Signed Statements, either separately, or inside Registration Policies.
 Transparency Services MUST authenticate Signed Statements as part of a Registration Policy.
-For instance, a trust anchor could be an X.509 root certificate, a pointer to an OpenID Connect identity provider, or any other COSE-compatible trust anchor.
+For instance, a trust anchor could be an X.509 root certificate (directly or its thumbprint), a pointer to an OpenID Connect identity provider, or any other COSE-compatible trust anchor.
 
 Registration Policies and trust anchors MUST be made transparent and available to all Relying Parties of the Transparency Service by registering them as Signed Statements on the Append-only Log, and distributing the associated Receipts.
 


### PR DESCRIPTION
Addressing a concern raised by @briankr-ms, to clarify that the registration policies can contain trust anchors. To give a concrete example, scitt-ccf-ledger policies can contain one or more trust anchors in the following way:

```
export function apply(profile, phdr) {
if (phdr.cwt.iss.startsWith("did:x509:0:sha256:HnwZ4lezuxq_GVcl_Sk7YWW170qAD0DZBLXilXet0jg::eku::..."))
{
...
```

Which encodes the thumbprint of a trust anchor, and the constraint that the leaf of x5chain must have certain EKU bits set. More detail can be found if desired at https://github.com/microsoft/did-x509

For the avoidance of doubt, this is _not_ trying to mention `did` in the draft. This is just clarifying that roots of trust can be encoded in policy. One could also imagine a `did`-free policy along of the lines of:

```
export function apply(profile, phdr) {
if (thumbprint(phdr.x5chain[0]) == "f5ceec3fd104994da13b32e8bdc21bd864e4e7f579ecd157c38c15c1b2390c9f"))
{
...
```

Having them inline is not just a convenience, some use cases will have a non-trivial mapping between acceptable statements and trust anchors, and the set of anchors alone will not be sufficient for a complete audit in that case.