### PR TITLE
Allow Registering Transparent Statements

### DIFF
--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -760,7 +760,11 @@ A Transparency Service MUST ensure that a Signed Statement is registered before 
 
 A Transparency Service MAY accept a Signed Statement with content in its unprotected header, and MAY use values from that unprotected header during verification and registration policy evaluation.
 
-However, the unprotected header of a Signed Statement MUST be set to an empty map before the Signed Statement can be included in a Statement Sequence.
+To support registering a Transparent Statement from a first Transparency Service, with a second Transparency Services, while maintaining the ability to refer to Transparent Statements by hash requires normalizing the unprotected header.
+
+Normalization procedures for unprotected header are a registration policy specific activity, and are out of scope for this document.
+
+Some Transparency Services MAY decide to not support registering Transparent Statements.
 
 The same Signed Statement may be independently registered in multiple Transparency Services, producing multiple, independent Receipts.
 The multiple Receipts may be attached to the unprotected header of the Signed Statement, creating a Transparent Statement.

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -760,11 +760,7 @@ A Transparency Service MUST ensure that a Signed Statement is registered before 
 
 A Transparency Service MAY accept a Signed Statement with content in its unprotected header, and MAY use values from that unprotected header during verification and registration policy evaluation.
 
-To support registering a Transparent Statement from a first Transparency Service, with a second Transparency Services, while maintaining the ability to refer to Transparent Statements by hash requires normalizing the unprotected header.
-
-Normalization procedures for unprotected header are a registration policy specific activity, and are out of scope for this document.
-
-Some Transparency Services MAY decide to not support registering Transparent Statements.
+Transparency Services MAY alter or discard the unprotected header of any Signed Statement prior to registration.
 
 The same Signed Statement may be independently registered in multiple Transparency Services, producing multiple, independent Receipts.
 The multiple Receipts may be attached to the unprotected header of the Signed Statement, creating a Transparent Statement.


### PR DESCRIPTION
Consider the case where a "Hardware Vendor" signs a statement, which is made transparent in an "Operating System Vendor"s transparency service.... and then this Transparent Statement (including the receipt from the OS vendor) is registered with a "Government Regulator" Transparency Service.

Previously, we forbid this use case, by mandating the unprotected header be set to empty.
This also caused us to drop cert chains, and counter signatures.

This PR allows:

- higher order receipts (receipts for transparent statements)
- making cert chains transparent, along with their signed statement
- making counter signatures transparent, along with their signed statement

It clarifies that support for making transparent statements transparent is optional, not all transparency services will decide to support the cases above... none the less, the architecture should allow vendors to decide.