### PR TITLE
Removed un-necessary EQUIVOCATION reference

### DIFF
--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -128,8 +128,6 @@ informative:
     target: https://cyclonedx.org/specification/overview/
     title: CycloneDX
 
-  EQUIVOCATION: DOI.10.1145/1323293.1294280
-
   in-toto:
     target: https://in-toto.io/
     title: in-toto
@@ -393,7 +391,7 @@ In COSE, an Envelope consists of a protected header (included in the Issuer's si
 
 Equivocation:
 
-: a state where a Transparency Service provides inconsistent proofs to Relying Parties, containing conflicting claims about the Signed Statement bound at a given position in the Verifiable Data Structure {{EQUIVOCATION}}.
+: a state where a Transparency Service provides inconsistent proofs to Relying Parties, containing conflicting claims about the Signed Statement bound at a given position in the Verifiable Data Structure.
 
 Issuer:
 


### PR DESCRIPTION
Address item from #383 

> Informative References, Equivocation: This source doesn't appear to be freely available at the source you list. However, I found it here too: https://www.read.seas.harvard.edu/~kohler/class/08w-dsi/chun07attested.pdf

The reference is not needed, the fact that there is not a good public link for it does not need to be a problem.