### PR TITLE
Disambiguate sub-domains

### DIFF
--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -578,7 +578,7 @@ The Verifiable Data Structure records registered Signed Statements and supports 
 
 Typically a Transparency Service has a single Issuer identity which is present in the `iss` Claim of Receipts for that service.
 
-Multi-tenant support can be enabled through the use of identifiers in the `iss` Claim, for example, `ts.example` may have a distinct Issuer identity for each sub domain, such as `customer1.ts.example` and `customer2.ts.example`.
+Multi-tenant support can be enabled through the use of identifiers in the `iss` Claim, for example, `ts.example.` may have a distinct Issuer identity for each sub domain, such as `tenant1.ts.example.` and `tenant2.ts.example.`.
 
 ### Registration Policies
 


### PR DESCRIPTION
Towards #384

> Section 5.1, last para: idnits is confused about the concept of 'sub domain' and something that doesn't really qualify to be a sub domain in the DNS sense (customer1.ts.example). If this para is meant to be describing something called 'sub domain' in the DNS sense, then can we change the example names to comply with that scheme. If sub domain means something different, then maybe we can use another word to describe it? (my objective here is clarity)