### PR TITLE
Clarify Transparent Statement Schema

### DIFF
--- a/signed_statement.cddl
+++ b/signed_statement.cddl
@@ -14,6 +14,7 @@ Protected_Header = {
   ? &(content_type: 3) => tstr / uint
   ? &(kid: 4) => bstr
   ? &(x5t: 34) => COSE_CertHash
+  ? &(x5chain: 33) => COSE_X509
   * int => any
 }
 


### PR DESCRIPTION
Editorial change to make the CDDL clearer and more consistent with 5.1.1.1:

> The protected header of the COSE_Sign1 Envelope MUST include either the Issuer's certificate as x5t or the chain including the Issuer's certificate as x5chain. If x5t is included in the protected header, an x5chain with a leaf certificate corresponding to the x5t value MAY be included in the unprotected header.

And 6:

> When using x.509 certificates, support for either x5t or x5chain in the protected header is REQUIRED to implement.

There is no normative change, this was always covered by `* int => any`.
