### PR TITLE
Fix typo in CoAP ID made in #407

### DIFF
--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -1179,6 +1179,6 @@ Author/Change controller:
 IANA is requested to register the following Content-Format numbers in the "CoAP Content-Formats" sub-registry, within the "Constrained RESTful Environments (CoRE) Parameters" Registry {{!IANA.core-parameters}} in the 256-9999 Range:
 
 | Content-Type                     | Content Coding | ID | Reference |
-| application/scitt-statement+cose | -              | 227 | {{&SELF}} |
+| application/scitt-statement+cose | -              | 277 | {{&SELF}} |
 | application/scitt-receipt+cose   | - | 278 | {{&SELF}} |
 {: #new-content-formats title="SCITT Content-Formats Registration"}


### PR DESCRIPTION
Editorial change to correct the ID value.

```
Hello Henk,

Assigning 277 and 278 is okay for me!

@IANA/David: The registration request can be approved when the new media type registrations are approved.

best regards,
Esko

On 20-8-2025 18:07, Henk Birkholz wrote:
Hello Esko,

thank you! Valid question. We discussed this and our reply is essentially: as you rightfully suspected, we do not need to stay in the 0-255 range.

After a quick look at the registry, would you be okay with:

| Content-Type                     | Content Coding | ID  | Reference |
| application/scitt-statement+cose | -              | 277 | {{&SELF}} |
| application/scitt-receipt+cose   | -              | 278 | {{&SELF}} |


For the I-D authors,

Henk
```
https://mailarchive.ietf.org/arch/msg/scitt/W1to1uydFiXvSAyZ2g_j4112Oao/