### PR TITLE
Fix grammatical mistake in Relying Party definition

### DIFF
--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -422,7 +422,7 @@ Registration Policy:
 
 Relying Party:
 
-: a Relying Parties consumes Transparent Statements, verifying their proofs and inspecting the Statement payload, either before using corresponding Artifacts, or later to audit an Artifact's provenance on the supply chain.
+: Relying Parties consumes Transparent Statements, verifying their proofs and inspecting the Statement payload, either before using corresponding Artifacts, or later to audit an Artifact's provenance on the supply chain.
 
 Signed Statement:
 


### PR DESCRIPTION
Spotted in Gen-ART review, editorial change.

```
Nits/editorial comments:
Small nit. Section 3 in the relying party term: a relying parties. Either
without the a or party instead of parties.
```

https://mailarchive.ietf.org/arch/msg/scitt/BZFRF94GmGucm4Y_cM_RRbNgYrQ/