### PR TITLE
Remove unused RFC9334 reference from the document

### DIFF
--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -116,7 +116,6 @@ informative:
   RFC4949: Glossary
   RFC8725:
   RFC9162: CT
-  RFC9334: RATS
 
   CoSWID: RFC9393
 


### PR DESCRIPTION
Towards #412