### PR TITLE
Update architecture definition for clarity and extensibility

### DIFF
--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -161,8 +161,8 @@ entity:
 
 Traceability in supply chains is a growing security concern.
 While verifiable data structures have addressed specific issues, such as equivocation over digital certificates, they lack a universal architecture for all supply chains.
-This document defines a scalable architecture for single-issuer signed statement transparency applicable to any supply chain.
-It ensures flexibility, interoperability between different transparency services, and compliance with various auditing procedures and regulatory requirements.
+This document defines such an architecture for single-issuer signed statement transparency.
+It ensures extensibility, interoperability between different transparency services, and compliance with various auditing procedures and regulatory requirements.
 
 --- middle
 


### PR DESCRIPTION
Towards #414.

The introduction already justifies extensibility, I have left that unchanged.

> The application-domain-agnostic nature of COSE_Sign1 and its extensibility through COSE Header Parameters are prerequisites for implementing the interoperable message layer defined in this document.