### PR TITLE
Replace "federation" with "collective baseline"

### DIFF
--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -513,7 +513,7 @@ Considering CT in terms of SCITT:
 
 # Architecture Overview
 
-The SCITT architecture enables a loose federation of Transparency Services, by providing a set of common formats and protocols for issuing and registering Signed Statements and auditing Transparent Statements.
+The SCITT architecture enables Transparency Services in a given application domain to implement a collective baseline, by providing a set of common formats and protocols for issuing and registering Signed Statements and auditing Transparent Statements.
 
 In order to accommodate as many Transparency Service implementations as possible, this document only specifies the format of Signed Statements (which must be used by all Issuers) and a very thin wrapper format for Receipts, which specifies the Transparency Service identity and the agility parameters for the Signed Inclusion Proofs.
 The remaining details of the Receipt's contents are specified in {{-RECEIPTS}}.


### PR DESCRIPTION
Towards #441

This is implicitly a transparency and auditability baseline, but it seemed heavy to repeat it.