### PR TITLE
Add key management reference

### DIFF
--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -985,7 +985,7 @@ Issuers and Transparency Services MUST:
 
 - carefully protect their private signing keys
 - avoid using keys for more than one purpose
-- rotate their keys in well-defined cryptoperiods (see {{Glossary}} for a definition)
+- rotate their keys at a cryptoperiod (defined in {{-Glossary}}) appropriate for the key algorithm and domain-specific regulations
 
 ### Verifiable Data Structure
 

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -117,7 +117,6 @@ informative:
   RFC4949: Glossary
   RFC8725:
   RFC9162: CT
-  RFC4949:
 
   CoSWID: RFC9393
 
@@ -986,7 +985,7 @@ Issuers and Transparency Services MUST:
 
 - carefully protect their private signing keys
 - avoid using keys for more than one purpose
-- rotate their keys in well-defined cryptoperiods (see {{RFC4949}} for a definition)
+- rotate their keys in well-defined cryptoperiods (see {{Glossary}} for a definition)
 
 ### Verifiable Data Structure
 

--- a/draft-ietf-scitt-architecture.md
+++ b/draft-ietf-scitt-architecture.md
@@ -117,6 +117,7 @@ informative:
   RFC4949: Glossary
   RFC8725:
   RFC9162: CT
+  RFC4949:
 
   CoSWID: RFC9393
 
@@ -143,10 +144,6 @@ informative:
   SWID:
     target: https://csrc.nist.gov/Projects/Software-Identification-SWID/guidelines
     title: SWID Specification
-
-  KEY-MANAGEMENT:
-    target: https://csrc.nist.gov/pubs/sp/800/57/pt2/r1/final
-    title: NIST SP 800-57 Part 2 Rev. 1
 
   EQUIVOCATION:
     target: https://www.read.seas.harvard.edu/~kohler/class/08w-dsi/chun07attested.pdf
@@ -989,7 +986,7 @@ Issuers and Transparency Services MUST:
 
 - carefully protect their private signing keys
 - avoid using keys for more than one purpose
-- rotate their keys in well-defined cryptoperiods, see {{KEY-MANAGEMENT}}
+- rotate their keys in well-defined cryptoperiods (see {{RFC4949}} for a definition)
 
 ### Verifiable Data Structure
 


### PR DESCRIPTION
Towards the last item in #441, RFC4949 offers the following definition:

>    $ cryptoperiod
>       (I) The time span during which a particular key value is
>       authorized to be used in a cryptographic system. (See: key
>       management.)
> 
>       Usage: This term is long-established in COMPUSEC usage. In the
>       context of certificates and public keys, "key lifetime" and
>       "validity period" are often used instead.
> 
>       Tutorial: A cryptoperiod is usually stated in terms of calendar or
>       clock time, but sometimes is stated in terms of the maximum amount
>       of data permitted to be processed by a cryptographic algorithm
>       using the key. Specifying a cryptoperiod involves a tradeoff
>       between the cost of rekeying and the risk of successful
>       cryptoanalysis.
