### PR TITLE
Proposed correction for what looks like an accidental narrowing of COSE/RFC9052

### DIFF
--- a/signed_statement.cddl
+++ b/signed_statement.cddl
@@ -15,17 +15,19 @@ Protected_Header = {
   ? &(kid: 4) => bstr
   ? &(x5t: 34) => COSE_CertHash
   ? &(x5chain: 33) => COSE_X509
-  * int => any
+  * label => any
 }
 
 CWT_Claims = {
   &(iss: 1) => tstr
   &(sub: 2) => tstr
-  * int => any
+  * label => any
 }
 
 Unprotected_Header = {
   ? &(x5chain: 33) => COSE_X509
   ? &(receipts: 394)  => [+ Receipt]
-  * int => any
+  * label => any
 }
+
+label = int / tstr


### PR DESCRIPTION
The schema for signed statements narrows what COSE allows in [RFC 9052](https://www.rfc-editor.org/rfc/rfc9052.html#name-header-parameters), which defines labels as `int / tstr`.

Quoting Section 1.5 of RFC 9052:

> In COSE, we use text strings, negative integers, and unsigned integers as map keys. The integers are used for compactness of encoding and easy comparison. The inclusion of text strings allows for an additional range of short encoded values to be used as well.

As far as I can tell, the authors did not intend for this restriction to be there, and it seems to have happened accidentally.

CWT Claims gained its extra `* int` here: https://github.com/ietf-wg-scitt/draft-ietf-scitt-architecture/commit/72ccf8a1a81e52079a49ad57c72f1afaa20e864e, specifically after @OR13 noticed extra properties were disallowed: https://github.com/ietf-wg-scitt/draft-ietf-scitt-architecture/pull/163#discussion_r1457510308

There is no mention of deliberately excluding `tstr` or specifically enabling `int` only.

That line moved around a fair bit later, but was not edited again.

The unprotected header was aligned with the protected header here: https://github.com/ietf-wg-scitt/draft-ietf-scitt-architecture/pull/220, but again there is no mention of the restriction, and no further edits.

Finally, the initial setting of the protected header happened in https://github.com/ietf-wg-scitt/draft-ietf-scitt-architecture/pull/179. I have expanded the 100 comments it contains to find something relevant to the setting of `int` rather than `label` but was unable to find anything. Can I ask @OR13 if he remembers restricting the protected header that way on purpose, or if this was an accident?

The fact that this narrowing is not there in Receipts, neither as proposed by Orie in https://github.com/ietf-wg-scitt/draft-ietf-scitt-architecture/issues/109, nor in the current https://www.ietf.org/archive/id/draft-ietf-cose-merkle-tree-proofs-17.html#name-receipt-of-inclusion adds to my impression that this was an accident.